### PR TITLE
Add LO data and nodes set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,15 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.28" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
+log = { version = "0.4.14", default-features = false }
 logion-shared = { git = "https://github.com/logion-network/logion-shared", default-features = false,  branch = "polkadot-v0.9.28" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
+bs58 = "0.4.0"
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28" }
 

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -1,0 +1,46 @@
+use frame_support::traits::Get;
+use frame_support::weights::Weight;
+use frame_support::traits::OnRuntimeUpgrade;
+use sp_std::collections::btree_set::BTreeSet;
+
+use crate::{Config, PalletStorageVersion, pallet::StorageVersion};
+
+pub mod v2 {
+	use super::*;
+	use crate::{LegalOfficerSet, LegalOfficerNodes};
+
+	pub struct AddOnchainSettings<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for AddOnchainSettings<T> {
+
+		fn on_runtime_upgrade() -> Weight {
+			super::do_storage_upgrade::<T, _>(
+				StorageVersion::V1,
+				StorageVersion::V2AddOnchainSettings,
+				"AddOnchainSettings",
+				|| {
+					LegalOfficerSet::<T>::translate(|_, _: bool| Some(Default::default()));
+					LegalOfficerNodes::<T>::set(BTreeSet::new());
+				}
+			)
+		}
+	}
+}
+
+fn do_storage_upgrade<T: Config, F>(expected_version: StorageVersion, target_version: StorageVersion, migration_name: &str, migration: F) -> Weight
+where F: FnOnce() -> () {
+	let storage_version = PalletStorageVersion::<T>::get();
+	if storage_version == expected_version {
+		migration();
+
+		PalletStorageVersion::<T>::set(target_version);
+		log::info!("✅ {:?} migration successfully exected", migration_name);
+		T::BlockWeights::get().max_block
+	} else {
+		if storage_version != target_version {
+			log::warn!("❗ {:?} cannot run migration with storage version {:?} (expected {:?})", migration_name, storage_version, expected_version);
+		} else {
+			log::warn!("❎ {:?} execution skipped, already at target version {:?}", migration_name, target_version);
+		}
+		0
+	}
+}

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -33,13 +33,13 @@ where F: FnOnce() -> () {
 		migration();
 
 		PalletStorageVersion::<T>::set(target_version);
-		log::info!("✅ {:?} migration successfully exected", migration_name);
+		log::info!("✅ {:?} migration successfully executed", migration_name);
 		T::BlockWeights::get().max_block
 	} else {
 		if storage_version != target_version {
 			log::warn!("❗ {:?} cannot run migration with storage version {:?} (expected {:?})", migration_name, storage_version, expected_version);
 		} else {
-			log::warn!("❎ {:?} execution skipped, already at target version {:?}", migration_name, target_version);
+			log::info!("❎ {:?} execution skipped, already at target version {:?}", migration_name, target_version);
 		}
 		0
 	}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -77,6 +77,7 @@ impl EnsureOrigin<Origin> for EnsureManagerOriginMock {
 impl pallet_lo_authority_list::Config for Test {
 	type AddOrigin = EnsureManagerOriginMock;
 	type RemoveOrigin = EnsureManagerOriginMock;
+	type UpdateOrigin = EnsureManagerOriginMock;
 	type Event = Event;
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,31 +1,35 @@
-use crate::mock::*;
+use crate::{mock::*, LegalOfficerData, Error};
 use frame_support::{assert_err, assert_ok, error::BadOrigin, traits::EnsureOrigin};
 use logion_shared::IsLegalOfficer;
+use sp_core::OpaquePeerId;
 
 const LEGAL_OFFICER_ID: u64 = 1;
 const ANOTHER_ID: u64 = 2;
+const LEGAL_OFFICER_ID2: u64 = 3;
 
 #[test]
 fn it_adds_lo() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
 		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).is_some());
+		assert!(LoAuthorityList::legal_officer_nodes().is_empty());
 	});
 }
 
 #[test]
 fn it_removes_lo() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
 		assert_ok!(LoAuthorityList::remove_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
 		assert!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).is_none());
+		assert!(LoAuthorityList::legal_officer_nodes().is_empty());
 	});
 }
 
 #[test]
 fn it_fails_adding_if_not_manager() {
 	new_test_ext().execute_with(|| {
-		assert_err!(LoAuthorityList::add_legal_officer(Origin::signed(0), LEGAL_OFFICER_ID), BadOrigin);
+		assert_err!(LoAuthorityList::add_legal_officer(Origin::signed(0), LEGAL_OFFICER_ID, Default::default()), BadOrigin);
 	});
 }
 
@@ -39,7 +43,7 @@ fn it_fails_removing_if_not_manager() {
 #[test]
 fn it_ensures_origin_ok_as_expected() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
 		assert_ok!(LoAuthorityList::try_origin(Origin::signed(LEGAL_OFFICER_ID)));
 	});
 }
@@ -47,7 +51,7 @@ fn it_ensures_origin_ok_as_expected() {
 #[test]
 fn it_ensures_origin_err_as_expected() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
 		let result = LoAuthorityList::try_origin(Origin::signed(ANOTHER_ID));
 		assert!(result.err().is_some());
 	});
@@ -56,7 +60,7 @@ fn it_ensures_origin_err_as_expected() {
 #[test]
 fn it_detects_legal_officer() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
 		assert!(LoAuthorityList::is_legal_officer(&LEGAL_OFFICER_ID));
 	});
 }
@@ -64,7 +68,120 @@ fn it_detects_legal_officer() {
 #[test]
 fn it_detects_regular_user() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
 		assert!(!LoAuthorityList::is_legal_officer(&ANOTHER_ID));
+	});
+}
+
+#[test]
+fn it_lets_lo_update() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
+		let base_url = "https://node.logion.network".as_bytes().to_vec();
+		let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::update_legal_officer(Origin::signed(LEGAL_OFFICER_ID), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id.clone()),
+			base_url: Option::Some(base_url.clone()),
+		}));
+		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().base_url.unwrap(), base_url);
+		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().node_id.unwrap(), node_id);
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
+		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id));
+	});
+}
+
+#[test]
+fn it_lets_manager_update() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, Default::default()));
+		let base_url = "https://node.logion.network".as_bytes().to_vec();
+		let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::update_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id.clone()),
+			base_url: Option::Some(base_url.clone()),
+		}));
+		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().base_url.unwrap(), base_url);
+		assert_eq!(LoAuthorityList::legal_officer_set(LEGAL_OFFICER_ID).unwrap().node_id.unwrap(), node_id);
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
+		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id));
+	});
+}
+
+#[test]
+fn it_fails_add_if_peer_id_already_in_use() {
+	new_test_ext().execute_with(|| {
+		let base_url1 = "https://node1.logion.network".as_bytes().to_vec();
+		let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id1.clone()),
+			base_url: Option::Some(base_url1.clone()),
+		}));
+
+		let base_url2 = "https://node2.logion.network".as_bytes().to_vec();
+		assert_err!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID2, LegalOfficerData {
+			base_url: Option::Some(base_url2.clone()),
+			node_id: Option::Some(node_id1.clone()),
+		}), Error::<Test>::PeerIdAlreadyInUse);
+	});
+}
+
+#[test]
+fn it_fails_update_if_peer_id_already_in_use() {
+	new_test_ext().execute_with(|| {
+		let base_url1 = "https://node1.logion.network".as_bytes().to_vec();
+		let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id1.clone()),
+			base_url: Option::Some(base_url1.clone()),
+		}));
+
+		let base_url2 = "https://node2.logion.network".as_bytes().to_vec();
+		let node_id2 = OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID2, LegalOfficerData {
+			base_url: Option::Some(base_url2.clone()),
+			node_id: Option::Some(node_id2.clone()),
+		}));
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 2);
+		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id1));
+		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
+
+		assert_err!(LoAuthorityList::update_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID2, LegalOfficerData {
+			base_url: Option::Some(base_url2.clone()),
+			node_id: Option::Some(node_id1.clone()),
+		}), Error::<Test>::PeerIdAlreadyInUse);
+	});
+}
+
+#[test]
+fn it_updates_nodes_on_remove() {
+	new_test_ext().execute_with(|| {
+		let base_url = "https://node.logion.network".as_bytes().to_vec();
+		let node_id = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id.clone()),
+			base_url: Option::Some(base_url.clone()),
+		}));
+		assert_ok!(LoAuthorityList::remove_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID));
+		assert!(LoAuthorityList::legal_officer_nodes().is_empty());
+	});
+}
+
+#[test]
+fn it_updates_nodes_on_update() {
+	new_test_ext().execute_with(|| {
+		let base_url = "https://node.logion.network".as_bytes().to_vec();
+		let node_id1 = OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::add_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id1.clone()),
+			base_url: Option::Some(base_url.clone()),
+		}));
+		let node_id2 = OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap());
+		assert_ok!(LoAuthorityList::update_legal_officer(Origin::signed(MANAGER), LEGAL_OFFICER_ID, LegalOfficerData {
+			node_id: Option::Some(node_id2.clone()),
+			base_url: Option::Some(base_url.clone()),
+		}));
+
+		assert_eq!(LoAuthorityList::legal_officer_nodes().len(), 1);
+		assert!(LoAuthorityList::legal_officer_nodes().contains(&node_id2));
 	});
 }


### PR DESCRIPTION
* `LegalOfficerSet` now maps an address to some data (optional base URL and node ID)
* `LegalOfficerNodes` was added to replace the "well-known nodes" of `node-authorization` pallet
* After the migration to storage V2, no data are set. LOs and/or root will have to fill them in manually.

logion-network/logion-internal#575